### PR TITLE
Added support for: relURL, GA and math; Changed markup to goldmark as mmark is deprecated

### DIFF
--- a/exampleSite/content/post/math-typesetting.md
+++ b/exampleSite/content/post/math-typesetting.md
@@ -1,12 +1,11 @@
----
-author: Christian Decker
-title: Math Modeling
-date: 2019-08-07
-description: A brief guide to setup KaTeX
-markup: mmark
-math: true
-sec: 5
----
++++
+author = "Christian Decker"
+title = "Math Modeling"
+date = "2019-08-07"
+description = "A brief guide to setup KaTeX"
+math = "true"
+sec = "5"
++++
 
 _Source: content taken from [hugoBasicExample](https://github.com/gohugoio/hugoBasicExample). File: `math-typesetting.mmark`_
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,17 +18,17 @@
     <title>{{ if .Title }}{{ .Title }}{{ else }}{{ .Site.Title }}{{ end }}</title>
 
     <!-- Bootstrap Core CSS -->
-    <link href="css/bootstrap.min.css" rel="stylesheet">
+    <link href="{{ "css/bootstrap.min.css" | relURL }}" rel="stylesheet" type="text/css">
 
     <!-- Custom CSS -->
-    <link href="css/landing-page.css" rel="stylesheet">
+    <link href="{{ "css/landing-page.css" | relURL }}" rel="stylesheet" type="text/css">
 
     <!-- Custom Fonts -->
     <link href="https://fonts.googleapis.com/css?family=Lato:300,400,700,300italic,400italic,700italic" rel="stylesheet" type="text/css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
 
     <!-- Social Sharing buttons CSS -->
-    <link href="css/bootstrap-social.css" rel="stylesheet">
+    <link href="{{ "css/bootstrap-social.css" | relURL }}" rel="stylesheet" type="text/css">    
 
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
@@ -36,6 +36,9 @@
         <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
         <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
+
+    <!-- Global site tag (gtag.js) - Google Analytics Internal from HUGO-->
+    {{ template "_internal/google_analytics.html" . }}
 
     <style>
     {{ printf "%v" (partial "template.css" . ) | safeCSS  }} 

--- a/layouts/partials/main.html
+++ b/layouts/partials/main.html
@@ -15,6 +15,10 @@
                     <!-- <hr class="section-heading-spacer">
                     <div class="clearfix"></div>
                     -->
+                    <!-- Add kaTeX -->
+                    {{ if or .Params.math .Site.Params.math }}
+                        {{ partial "math.html" . }}
+                    {{ end }}
                     <h2 class="section-heading">{{ .Title }}</h2>
                     {{ replace .Content "<table>" "<table class='table table-striped table-hover'>" | safeHTML }}
                 </div>

--- a/layouts/partials/math.html
+++ b/layouts/partials/math.html
@@ -1,0 +1,22 @@
+<!-- Source: https://github.com/KevCaz/funkyflex/ -->
+
+<!-- Katex css -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.css" integrity="sha384-Um5gpz1odJg5Z4HAmzPtgZKdTBHZdw8S29IecapCSB31ligYPhHQZMIlWLYQGVoc" crossorigin="anonymous">
+
+<!-- The loading of KaTeX is deferred to speed up page rendering -->
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/katex.min.js" integrity="sha384-YNHdsYkH6gMx9y3mRkmcJ2mFUjTd0qNQQvY9VYZgQd7DcN7env35GzlmFaZ23JGp" crossorigin="anonymous"></script>
+
+<!-- To automatically render math in text elements, include the auto-render extension: -->
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.13.11/dist/contrib/auto-render.min.js" integrity="sha384-vZTG03m+2yp6N6BNi5iM4rW4oIwk5DfcNdFfxkk9ZWpDriOkXX8voJBFrAO7MpVl" crossorigin="anonymous"
+onload="renderMathInElement(document.body);"></script>
+
+<script>
+    document.addEventListener("DOMContentLoaded", function() {
+        renderMathInElement(document.body, {
+            delimiters: [
+                {left: "$$", right: "$$", display: true},
+                {left: "$", right: "$", display: false}
+            ]
+        });
+    });
+</script>


### PR DESCRIPTION
Added support for: relURL, GA and math; Changed markup to goldmark as mmark is deprecated.

The css files are loaded using `relURL` and support for Google Analytics and math rendering has been added.
Additionally, as mmark is deprecated, the markup has been changed to goldmark.

@cdeck3r